### PR TITLE
add cypress-localstorage-commands to installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ First, install Cypress in the root of your Magento 2 project;
 ```bash
 npm init
 npm install cypress --save-dev
-npm install cypress-file-upload --save-dev
+npm install cypress-file-upload cypress-localstorage-commands --save-dev
 ```
 
 The easiest way to install the tests is to clone this repository and move the `cypress` folder into your project. As of right now, we do not provide a fallback mechanism for customizations to the tests, see [Limitations](https://github.com/elgentos/magento2-cypress-testing-suite/blob/main/README.md#no-extensibility--inheritance-of-tests).


### PR DESCRIPTION
If you follow current install instructions an error is thrown:

```
Oops...we found an error preparing this test file:

  > cypress/support/index.js

The error was:

Error: Can't walk dependency graph: Cannot find module 'cypress-localstorage-commands' from '/var/www/html/cypress/support/commands.js'
    required by /var/www/html/cypress/support/commands.js
    at /var/www/html/node_modules/resolve/lib/async.js:146:35
    at processDirs (/var/www/html/node_modules/resolve/lib/async.js:299:39)
    at isdir (/var/www/html/node_modules/resolve/lib/async.js:306:32)
    at /var/www/html/node_modules/resolve/lib/async.js:34:69
    at callback (~/.cache/Cypress/9.5.0/Cypress/resources/app/node_modules/graceful-fs/polyfills.js:299:20)
    at FSReqCallback.oncomplete (node:fs:198:21)


This occurred while Cypress was compiling and bundling your test code. This is usually caused by:

- A missing file or dependency
- A syntax error in the file or one of its dependencies

Fix the error in your code and re-run your tests.
```

To fix this I added `cypress-localstorage-commands` to the dependencies.