### PR TITLE
fix(docs): add all required packages to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ First, install Cypress in the root of your Magento 2 project;
 ```bash
 npm init
 npm install cypress --save-dev
-npm install cypress-file-upload cypress-localstorage-commands --save-dev
+npm install cypress-file-upload cypress-localstorage-commands cypress-tags typescript --save-dev
 ```
 
 The easiest way to install the tests is to clone this repository and move the `cypress` folder into your project. As of right now, we do not provide a fallback mechanism for customizations to the tests, see [Limitations](https://github.com/elgentos/magento2-cypress-testing-suite/blob/main/README.md#no-extensibility--inheritance-of-tests).


### PR DESCRIPTION
I set up the project, opened cypress and it told me I need `cypress-tags` and `typescript` - installed these in the project but figured others might run into this too.