### PR TITLE
fix: don't stop running all other tests when one failed if running headless

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -6,9 +6,7 @@ Cypress.on('uncaught:exception', (err, runnable) => {
 })
 
 afterEach( function () {
-    if (this.currentTest.state === 'failed') {
+    if (!Cypress.browser.isHeadless && this.currentTest.state === 'failed') {
         Cypress.runner.stop()
     }
-});
-
-
+})


### PR DESCRIPTION
We noticed no tests were running in our CI environment where [automatic retries](https://docs.cypress.io/guides/guides/test-retries#Configure-Test-Retries) take care of the performance difference of the CI environment. Only failing the tests when not running headless keeps the development benefit but usually when running headless you want an overview of all failing tests.

This could probably be changed with an `CYPRESS_RUNNING_IN_CI` env variable or something like that but checking for headless works well enough in our use case and doesn't require a new variable.