### PR TITLE
feat: add commands to assert success messages, error messages and page titles

### DIFF
--- a/cypress/fixtures/globalSelectors.json
+++ b/cypress/fixtures/globalSelectors.json
@@ -1,0 +1,5 @@
+{
+    "successMessage": ".message-success.success",
+    "errorMessage": ".message-error",
+    "pageTitle": "h1.page-title .base"
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,4 +1,5 @@
 import 'cypress-localstorage-commands'
+import globalSelectors from '../fixtures/globalSelectors.json'
 
 Cypress.Commands.add('login', (email, pw) => {
     it('Test login', () => {
@@ -7,4 +8,22 @@ Cypress.Commands.add('login', (email, pw) => {
         cy.get('#pass').type(`${pw}{enter}`, {force:true})
         //cy.get('#login-form').contains('Inloggen').click({force:true})
     })
+})
+
+Cypress.Commands.add('shouldHavePageTitle', title => {
+    cy.get(globalSelectors.pageTitle)
+        .should('exist')
+        .should('contain.text', title)
+})
+
+Cypress.Commands.add('shouldHaveSuccessMessage', message => {
+    cy.get(globalSelectors.successMessage)
+        .should('exist')
+        .should('contain.text', message)
+})
+
+Cypress.Commands.add('shouldHaveErrorMessage', message => {
+    cy.get(globalSelectors.errorMessage)
+        .should('exist')
+        .should('contain.text', message)
 })


### PR DESCRIPTION
This PR adds a few short helper functions:

* `shouldHavePageTitle`
* `shouldHaveSuccessMessage`
* `shouldHaveErrorMessage`

All of them pretty much do what their title says.

Example usage for checking if a success message is present:

```js
it('Can add a product to the cart from the product page', () => {
    cy.get(selectors.addToCartButton).click()
    cy.shouldHaveSuccessMessage(`You added ${product.simpleProductName} to your shopping cart.`)
})
```