### PR TITLE
Improve home page search term footer link test

### DIFF
--- a/cypress/integration/hyva/homepage.spec.js
+++ b/cypress/integration/hyva/homepage.spec.js
@@ -97,9 +97,10 @@ describe('Home page tests', () => {
         );
         cy.get(selectors.searchTerms).should(
             "have.length.at.least",
-            4,
-            "At least four popular search terms exist"
+            2,
+            "At least two popular search terms exist"
         );
+        cy.get(selectors.searchTerms).contains(product.simpleProductName)
     });
 
     it(["footer"], "Can visit Contact form in the footer", () => {


### PR DESCRIPTION
The expected number of at least 4 search terms seems arbitrary, since there is no guarantee any other search tests run before the home page test.

Instead confirm at least 2 search terms, one of which is the product that was searched for in a previous test within the same spec.