### PR TITLE
Improve homepage spec test isolation

### DIFF
--- a/cypress/fixtures/hyva/homepage.json
+++ b/cypress/fixtures/hyva/homepage.json
@@ -3,7 +3,7 @@
     "contactFormComment": "Cypress and Hyvä, making commerce fun again!",
     "contactFormSuccess": "Thanks for contacting us with your comments and questions. We'll respond to you very soon.",
     "homePageUrl": "/",
-    "pageTitleMyAccount": "My Account",
+    "pageTitleLogin": "Customer Login",
     "pageTitleSearchTerms": "Popular Search Terms",
     "subCategoryName": "Tops",
     "subscriptionFail": "This email address is already subscribed.",

--- a/cypress/integration/hyva/homepage.spec.js
+++ b/cypress/integration/hyva/homepage.spec.js
@@ -66,25 +66,12 @@ describe('Home page tests', () => {
            .should("be.visible");
     });
 
-    it(["footer"], "Can visit the My Account page in the footer", () => {
+    it(["footer"], "Can visit the login page from the footer", () => {
         cy.get(selectors.footerMyAccount).click();
-        Account.login(
-            account.customer.customer.email,
-            account.customer.password
-        );
         cy.get(selectors.pageTitle).should(
             "contain.text",
-            homepage.pageTitleMyAccount,
+            homepage.pageTitleLogin,
             "Page has the correct title"
-        );
-        cy.get(selectors.myAccountContactInformationBlock).should(
-            "contain.text",
-            (account.customer.customer.firstname + " " + account.customer.customer.lastname),
-            "Customer name is in the contact information section"
-        ).and(
-            "contain.text",
-            account.customer.customer.email,
-            "Customer email is in the contact information section"
         );
     });
 
@@ -95,10 +82,11 @@ describe('Home page tests', () => {
             homepage.pageTitleSearchTerms,
             "Page has the correct title"
         );
+        // assert at least one exists because this spec executes one search above
         cy.get(selectors.searchTerms).should(
             "have.length.at.least",
-            2,
-            "At least two popular search terms exist"
+            1,
+            "At least one popular search terms exist"
         );
         cy.get(selectors.searchTerms).contains(product.simpleProductName)
     });


### PR DESCRIPTION
Do not rely on a customer account created by the `user/account.spec.js` or search terms queried by `search/product-searches.spec.js`.
With these changes the homepage spec can be run in isolation or before any of the tests mentioned above.