### PR TITLE
Separate mainHeading selectors for products

### DIFF
--- a/cypress/fixtures/hyva/selectors/product.json
+++ b/cypress/fixtures/hyva/selectors/product.json
@@ -6,6 +6,7 @@
     "customerReviewTitle": ".product-info-main section h3",
     "errorMessage": ".message.error",
     "forgottenField": ".swatch-attribute :invalid",
+    "mainHeading": "h1.title-font",
     "productAttributeSelector": "#product_addtocart_form .swatch-attribute .product-option-value-label",
     "productCustomerReviews": "[itemprop=\"review\"]",
     "productCustomerReviewForm": "#review_form",

--- a/cypress/integration/hyva/catalog/product.spec.js
+++ b/cypress/integration/hyva/catalog/product.spec.js
@@ -11,7 +11,7 @@ describe('Simple Product test suite', () => {
     });
 
     it('Can see a title and image for the product', () => {
-        cy.get(homepageSelectors.mainHeading)
+        cy.get(selectors.mainHeading)
             .should('contain.text', product.simpleProductName)
             .should('be.visible');
         cy.get(selectors.productImage)


### PR DESCRIPTION
After doing a number of implementations, I've found the homepage mainHeading selector *almost always* differs from the product mainHeading selector so it makes sense to split them up. They keep the same default value.