### PR TITLE
Ensure the timeout value is a number

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -19,7 +19,7 @@ module.exports = defineConfig({
         baseUrl: baseUrl,
         specPattern: process.env.CYPRESS_MAGENTO2_SPEC_PATTERN || envConfig.MAGENTO2_SPEC_PATTERN || defaultSpecPattern,
         excludeSpecPattern: process.env.CYPRESS_MAGENTO2_EXCLUDE_PATTERN || envConfig.MAGENTO2_EXCLUDE_PATTERN || '',
-        defaultCommandTimeout: process.env.CYPRESS_MAGENTO2_DEFAULT_TIMEOUT || envConfig.MAGENTO2_DEFAULT_TIMEOUT || defaultCommandTimeout,
+        defaultCommandTimeout: parseInt(process.env.CYPRESS_MAGENTO2_DEFAULT_TIMEOUT || envConfig.MAGENTO2_DEFAULT_TIMEOUT || defaultCommandTimeout),
         watchForFileChanges: false,
         videoUploadOnPasses: false,
         supportFile: false,


### PR DESCRIPTION
This is required when a value is passed from an environment variable, because they are always taken to be strings.
This leads to the error:

```
Your configFile at /data/web/magento2/cypress.config.js set an invalid value:
Expected e2e.defaultCommandTimeout to be a number.
Instead the value was: "10000"
```