### PR TITLE
fix: properly register cypress localstorage commands

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -22,7 +22,7 @@ module.exports = defineConfig({
         defaultCommandTimeout: parseInt(process.env.CYPRESS_MAGENTO2_DEFAULT_TIMEOUT || envConfig.MAGENTO2_DEFAULT_TIMEOUT || defaultCommandTimeout),
         watchForFileChanges: false,
         videoUploadOnPasses: false,
-        supportFile: false,
+        supportFile: 'cypress/support/index.js',
         viewportWidth: 1920,
         viewportHeight: 1080,
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,1 @@
+import "cypress-localstorage-commands";


### PR DESCRIPTION
Without doing this, I get the following errors:
```
  1) Mini cart tests
       "before each" hook for "Can delete an item from the cart slider":
     TypeError: cy.restoreLocalStorage is not a function
```

According to the module's [documentation](https://github.com/javierbrea/cypress-localstorage-commands#installation), we must `import "cypress-localstorage-commands";` in the support file.

The support file was also disabled for some reason, so I have re-enabled it.