### PR TITLE
Fix fixture property names that caused the account tests to fail

### DIFF
--- a/cypress/page-objects/hyva/account.js
+++ b/cypress/page-objects/hyva/account.js
@@ -74,8 +74,7 @@ export class Account {
                 cy.get(selectors.defaultBillingAddress).check();
                 cy.get(selectors.defaultShippingAddress).check();
             }
-            cy.get(selectors.newAddressStreetInput).type(customerInfo.streetAddressStreet);
-            cy.get(selectors.newAddressHouseNumberInput).type(customerInfo.streetAddressNumber);
+            cy.get(selectors.newAddressStreetInput).type(customerInfo.streetAddress);
             cy.get(selectors.newAddressCityInput).type(customerInfo.city);
             cy.get(selectors.newAddressTelInput).type(customerInfo.phone);
             cy.get(selectors.newAddressZipcodeInput).type(customerInfo.zip);


### PR DESCRIPTION
I'm not sure how this happened, my guess is that at one point the data in `cypress/fixtures/account.json` was changed, but the references to the street and the house number in `cypress/page-objects/hyva/account.js` where not updated.

The old property names are used nowhere else within the repo, so I think it's safe to assume the luma tests where refactored, too, if they used them.

I'm too lazy to git-blame to try and figure out when that happened :)
