### PR TITLE
Fix broken tests

### DIFF
--- a/cypress/fixtures/globalSelectors.json
+++ b/cypress/fixtures/globalSelectors.json
@@ -1,5 +1,5 @@
 {
-    "successMessage": ".message-success.success",
+    "successMessage": ".message.success",
     "errorMessage": ".message-error",
     "pageTitle": "h1.page-title .base"
 }

--- a/cypress/fixtures/hyva/selectors/search.json
+++ b/cypress/fixtures/hyva/selectors/search.json
@@ -3,5 +3,5 @@
     "headerSearchIcon": "#menu-search-icon",
     "searchResults": ".search.results .products .card.card-interactive",
     "noResultsMessage": ".message.notice",
-    "searchSuggestions": "[x-text=\"suggestion.title\"]"
+    "searchSuggestions": "[x-text=\"searchResult.title\"]"
 }

--- a/cypress/integration/hyva/catalog/category.spec.js
+++ b/cypress/integration/hyva/catalog/category.spec.js
@@ -7,10 +7,7 @@ describe("Category page tests", () => {
     });
 
     it("Can visit the category page and filters on color red", () => {
-        cy.get(selectors.shopByColorFilter).contains('Color').click();
         cy.get(selectors.selectColorRed).click();
-
-        cy.get(selectors.shopByColorFilter).contains('Color').should("not.exist")
         cy.get(selectors.activeFilterLabel).should("contain.text", "Color")
         cy.get(selectors.activeFilterValue).should("contain.text", "Red")
     });

--- a/cypress/integration/hyva/search/product-searches.spec.js
+++ b/cypress/integration/hyva/search/product-searches.spec.js
@@ -39,7 +39,7 @@ describe('Perform searches', () => {
             .should('contain.text', 'Your search returned no results.');
     });
 
-    it.only('Can see suggestions when entering search terms', () => {
+    it('Can see suggestions when entering search terms', () => {
         cy.get(selectors.headerSearchIcon).click();
         cy.get(selectors.headerSearchField)
             .should('be.visible')

--- a/cypress/integration/hyva/search/product-searches.spec.js
+++ b/cypress/integration/hyva/search/product-searches.spec.js
@@ -1,5 +1,6 @@
 import { Search } from '../../../page-objects/hyva/search';
 import search from '../../../fixtures/hyva/search.json';
+import globalSelectors from '../../../fixtures/globalSelectors.json'
 import selectors from '../../../fixtures/hyva/selectors/search.json';
 import homepageSelectors from '../../../fixtures/hyva/selectors/homepage.json';
 
@@ -19,11 +20,10 @@ describe('Perform searches', () => {
 
     it('Can find a single product', () => {
         Search.search(search.singleProduct);
-        cy.get(homepageSelectors.mainHeading).should(
+        cy.get(globalSelectors.successMessage).should(
             'contain.text',
-            `Search results for: '${search.singleProduct}'`
+            `is the only product matching your '${search.singleProduct}' search.`
         );
-        cy.get(selectors.searchResults).should('have.lengthOf', 1)
     });
 
     it('Can perform search with no search results', () => {
@@ -39,7 +39,7 @@ describe('Perform searches', () => {
             .should('contain.text', 'Your search returned no results.');
     });
 
-    it('Can see suggestions when entering search terms', () => {
+    it.only('Can see suggestions when entering search terms', () => {
         cy.get(selectors.headerSearchIcon).click();
         cy.get(selectors.headerSearchField)
             .should('be.visible')


### PR DESCRIPTION
This resolves #82

Looks like there were some changes to the site:
- So single product searches now redirect directly to the product page so I changed the test to check for the success message
- Category already had color opened so it was no longer needed to select color before choosing red. I was also not sure what the line `cy.get(selectors.shopByColorFilter).contains('Color').should("not.exist")` was supposed. It did not make sense since the color selector will exist since we just used it, so I removed that line. But happy to adjust if I can better understand what we are checking here.
