### PR TITLE
Adding retries to look for flakiness

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -27,6 +27,7 @@ module.exports = defineConfig({
         excludeSpecPattern: process.env.CYPRESS_MAGENTO2_EXCLUDE_PATTERN || envConfig.MAGENTO2_EXCLUDE_PATTERN || '',
         defaultCommandTimeout: parseInt(process.env.CYPRESS_MAGENTO2_DEFAULT_TIMEOUT || envConfig.MAGENTO2_DEFAULT_TIMEOUT || defaultCommandTimeout),
         videoUploadOnPasses: !! (process.env.CYPRESS_VIDEO_UPLOAD_ON_PASSES || envConfig.VIDEO_UPLOAD_ON_PASSES || false),
+        retries: 3,
         watchForFileChanges: false,
         supportFile: 'cypress/support/index.js',
         viewportWidth: 1920,


### PR DESCRIPTION
I was unable to reproduce this issue #86 in my CI run (See screenshot below of successful run with all tests passing), but just in case I added retries to look for flakiness in the tests. This has been super helpful for us on Luma since Luma is so heavy JS based and sometimes a script just takes too long to load and messes up a test.

https://docs.cypress.io/guides/guides/test-retries.html

![image](https://user-images.githubusercontent.com/2414175/192170625-b724210e-09fa-4563-a469-7f96dc87850e.png)
