### PR TITLE
Make rest api methods available as cy commands

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,1 +1,4 @@
 import "cypress-localstorage-commands";
+import {Magento2RestApi} from './magento2-rest-api';
+
+Cypress.Commands.addAll(Magento2RestApi)


### PR DESCRIPTION
This helps avoid having to specify relative import paths from tests in modules.