### PR TITLE
Refactor luma account tests

### DIFF
--- a/cypress/page-objects/luma/account.js
+++ b/cypress/page-objects/luma/account.js
@@ -12,7 +12,7 @@ export class Account {
     static isLoggedIn() {
         cy.contains(selectors.myAccountHeaderSelector, 'My Account')
     }
-    
+
     static logout() {
         cy.visit(account.routes.accountIndex);
         cy.get('.base').then(($text) => {
@@ -82,6 +82,32 @@ export class Account {
             cy.get('#zip').type(customerInfo.zip)
             cy.get('#country').select(customerInfo.country)
             cy.contains('Save Address').click()
+        })
+    }
+
+    static deleteAddress() {
+        cy.visit(account.routes.accountAddresses)
+        cy.wait(2000)
+
+        cy.get('.block-addresses-list').then($block => {
+            cy.log($block.find('.empty').length)
+            if ($block.find('.empty').length === 1) {
+                cy.log('No more addresses to remove');
+            } else {
+                // TODO: Replace this with REST API call at some point?
+                cy.get('.additional-addresses a.delete').then(($links) => {
+                    if ($links.length > 0) {
+                        cy.wrap($links.first()).click({force: true});
+                        cy.wait(2000)
+                        cy.get('.modal-content').then(($modal) => {
+                            if ($modal.text().indexOf('Are you sure you want to delete this address?') >= 0) {
+                                cy.get('.action-primary').click()
+                            }
+                            this.deleteAddress(); // calling as long as we have addresses to remove!
+                        })
+                    }
+                })
+            }
         })
     }
 

--- a/cypress/support/magento2-rest-api.js
+++ b/cypress/support/magento2-rest-api.js
@@ -20,6 +20,30 @@ export class Magento2RestApi {
         });
     }
 
+    static replacePassword(username, oldPassword, newPassword) {
+        cy.request({
+            method: 'POST',
+            url: '/rest/all/V1/integration/customer/token',
+            body: {
+                "username": username,
+                "password": oldPassword
+            },
+        }).then((response) => {
+            let token = response.body
+            cy.request({
+                method: 'PUT',
+                url: '/rest/default/V1/customers/me/password',
+                headers: {
+                    Authorization: "Bearer " + token
+                },
+                body: {
+                    "currentPassword": oldPassword,
+                    "newPassword": newPassword
+                }
+            })
+        })
+    }
+
     static logCustomerIn(customer) {
         cy.request({
             method: 'POST',


### PR DESCRIPTION
Cleanup of Account Spec tests for Luma theme. Things done:
1. Break down the **Account Activities** and create **Account login/logout** and **Account Address Activities** to better separate the test logic (and optimize the usage of before/beforeEach/after in each of them)
2. Introduction of `Magento2RestApi.replacePassword()` to not rely on the frontend to change the password back
3. Introduction of `Account.deleteAddress()` to handle Addresses cleanup after **Account Address Activities** tests
4. Left some TODOs that can be extracted as separate issues and can be a good FirstIssue type for the project