### PR TITLE
Adding accessibility tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,15 @@ cypress/videos
 cypress.env.json
 ```
 
+### Accessibility test installation
+
+The accessibility test specs use cypress-axe and as such need extra items installed via npm.
+
+```bash
+npm install --save-dev cypress-axe
+npm install --save-dev axe-core
+```
+
 ## Setup
 
 Some tests are dependent on making changes in the database. This is done through the Magento 2 REST API. You will need to create an admin token for these tests. This is easily done using [magerun2](https://github.com/netz98/n98-magerun2).
@@ -294,6 +303,19 @@ CYPRESS_MAGENTO2_SPEC_SUITE=vue npx cypress run
 ```
 
 If you do not want all tests to be run, regardless of the folder names, set `MAGENTO2_SPEC_SUITE` to an empty string.
+
+### Running accessibility tests
+
+Accessibility spec files will not be found by the default spec pattern.
+This was desired as they should be seen as optional.
+
+To run the accessibility tests locally you can update your cypress.env.json to include the following
+
+```json
+{
+    "MAGENTO2_SPEC_PATTERN": "cypress/integration/luma-accessibility/**/*.spec.js"
+}
+```
 
 ## Videos
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -57,6 +57,15 @@ module.exports = defineConfig({
 
             on('file:preprocessor', tagify(config))
 
+            on('task', {
+                axetable(message) {
+                    console.table(message, ['impact', 'description', 'nodes'] );
+                    console.log("Details")
+                    console.log(message.map(m => `"${m.id}:" \n ${m.html}`).join('\n\n'));
+                    return null;
+                },
+            });
+
             const applySpecSuiteToSpecPattern = (config) => {
                 // If the specSuite is an empty string, add a trailing / to $SPEC_SUITE to avoid // in the pattern
                 const regex = config.specSuite === '' ? /\$SPEC_SUITE\//g : /\$SPEC_SUITE/g;

--- a/cypress/fixtures/account.json
+++ b/cypress/fixtures/account.json
@@ -24,6 +24,7 @@
         "accountAddresses": "/customer/address",
         "accountCreate": "/customer/account/create",
         "accountEdit": "/customer/account/edit",
+        "accountForgottenPassword": "/customer/account/forgotpassword",
         "accountIndex": "/customer/account/index",
         "accountOrderHistory": "/sales/order/history",
         "accountUrl": "/customer/account",

--- a/cypress/integration/luma-accessibility/cart/cart.spec.js
+++ b/cypress/integration/luma-accessibility/cart/cart.spec.js
@@ -1,0 +1,14 @@
+import { Cart } from '../../../page-objects/luma/cart';
+import cartLuma from '../../../fixtures/luma/selectors/cart';
+import {checkAccessibility} from "../../../support/utils"
+
+describe('Cart accessibility tests', () => {
+    it('Check cart', () => {
+        Cart.addProductToCart(cartLuma.url.product1Url);
+        cy.visit(cartLuma.url.cartUrl);
+        cy.wait(3000);
+
+        cy.injectAxe()
+        checkAccessibility()
+    });
+});

--- a/cypress/integration/luma-accessibility/cart/minicart.spec.js
+++ b/cypress/integration/luma-accessibility/cart/minicart.spec.js
@@ -1,0 +1,18 @@
+import minicart from "../../../fixtures/minicart"
+import selectors from "../../../fixtures/luma/selectors/minicart"
+import {checkAccessibility} from "../../../support/utils"
+
+describe('Mini cart accessibility tests', () => {
+    it('Check mini cart', () => {
+        cy.restoreLocalStorage();
+        cy.clearCookies();
+        cy.visit(minicart.didiSportWatch)
+        cy.get(selectors.addToCartButton).click()
+        cy.wait(5000)
+        cy.get(selectors.miniCartButton).click()
+        cy.wait(2000)
+
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/checkout/checkout.spec.js
+++ b/cypress/integration/luma-accessibility/checkout/checkout.spec.js
@@ -15,7 +15,7 @@ describe('Checkout accessibility tests', () => {
 
         cy.injectAxe()
         // We need to set skip failures as true here otherwise the tests will not proceed to the next checkout step
-        checkAccessibility(null, null, null, true)
+        checkAccessibility(null, null, true)
 
         Checkout.enterShippingAddress(checkout.shippingAddress)
         cy.wait(3000)

--- a/cypress/integration/luma-accessibility/checkout/checkout.spec.js
+++ b/cypress/integration/luma-accessibility/checkout/checkout.spec.js
@@ -1,0 +1,28 @@
+import {Checkout} from "../../../page-objects/luma/checkout";
+import product from '../../../fixtures/luma/product'
+import checkout from '../../../fixtures/checkout'
+import selectors from '../../../fixtures/luma/selectors/checkout'
+import {checkAccessibility} from "../../../support/utils"
+
+describe('Checkout accessibility tests', () => {
+    it('Check Checkout steps', () => {
+        cy.visit(product.simpleProductUrl)
+        cy.get(selectors.addToCartButton).click()
+
+        cy.wait(3000)
+        cy.visit(checkout.checkoutUrl)
+        cy.wait(5000)
+
+        cy.injectAxe()
+        // We need to set skip failures as true here otherwise the tests will not proceed to the next checkout step
+        checkAccessibility(null, null, null, true)
+
+        Checkout.enterShippingAddress(checkout.shippingAddress)
+        cy.wait(3000)
+        cy.get('.button.action.continue.primary').click()
+        cy.wait(5000)
+
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/checkout/guest-checkout.spec.js
+++ b/cypress/integration/luma-accessibility/checkout/guest-checkout.spec.js
@@ -4,8 +4,8 @@ import checkout from '../../../fixtures/checkout'
 import selectors from '../../../fixtures/luma/selectors/checkout'
 import {checkAccessibility} from "../../../support/utils"
 
-describe('Checkout accessibility tests', () => {
-    it('Check Checkout steps', () => {
+describe('Guest checkout accessibility tests', () => {
+    it('Check Checkout steps as guest', () => {
         cy.visit(product.simpleProductUrl)
         cy.get(selectors.addToCartButton).click()
 

--- a/cypress/integration/luma-accessibility/checkout/user-checkout.spec.js
+++ b/cypress/integration/luma-accessibility/checkout/user-checkout.spec.js
@@ -1,0 +1,46 @@
+import product from '../../../fixtures/luma/product'
+import checkout from '../../../fixtures/checkout'
+import selectors from '../../../fixtures/luma/selectors/checkout'
+import {checkAccessibility} from "../../../support/utils"
+import {Magento2RestApi} from "../../../support/magento2-rest-api";
+import account from "../../../fixtures/account.json";
+import {Account} from "../../../page-objects/luma/account";
+
+describe('User checkout accessibility tests', () => {
+    after(() => {
+        // Remove the added address
+        cy.wait(4000)
+        cy.visit(account.routes.accountAddresses)
+        cy.wait(4000)
+        cy.get('.additional-addresses a.delete').eq(0).click({force: true})
+        cy.wait(1000)
+        cy.get('.modal-content').contains('Are you sure you want to delete this address?')
+        cy.get('.action-primary').click()
+        cy.wait(2500)
+    })
+
+    it('Check Checkout steps as user', () => {
+        Magento2RestApi.createCustomerAccount(account.customer)
+        Account.login(account.customer.customer.email, account.customer.password)
+        Account.createAddress(account.customerInfo)
+
+        cy.visit(product.simpleProductUrl)
+        cy.get(selectors.addToCartButton).click()
+
+        cy.wait(3000)
+        cy.visit(checkout.checkoutUrl)
+        cy.wait(5000)
+
+        cy.injectAxe()
+        // We need to set skip failures as true here otherwise the tests will not proceed to the next checkout step
+        checkAccessibility(null, null, true)
+
+        cy.wait(3000)
+        cy.get('.button.action.continue.primary').click()
+        cy.wait(5000)
+
+        cy.injectAxe()
+        // We need to set skip failures as true here so the after gets called
+        checkAccessibility(null, null, true)
+    })
+})

--- a/cypress/integration/luma-accessibility/homepage.spec.js
+++ b/cypress/integration/luma-accessibility/homepage.spec.js
@@ -1,0 +1,13 @@
+import homepage from "../../fixtures/luma/homepage"
+import {checkAccessibility} from "../../support/utils"
+
+describe('Home page accessibility tests', () => {
+    beforeEach(() => {
+        cy.visit(homepage.homePageUrl)
+    })
+
+    it('Check Homepage', () => {
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/products/category.spec.js
+++ b/cypress/integration/luma-accessibility/products/category.spec.js
@@ -1,0 +1,12 @@
+import product from '../../../fixtures/luma/product'
+import {checkAccessibility} from "../../../support/utils"
+
+describe('Category page accessibility tests', () => {
+    it('Check category page', () => {
+        cy.visit(product.categoryUrl)
+        cy.wait(3000)
+
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/products/product-configurable.spec.js
+++ b/cypress/integration/luma-accessibility/products/product-configurable.spec.js
@@ -1,0 +1,12 @@
+import product from "../../../fixtures/luma/product"
+import {checkAccessibility} from "../../../support/utils"
+
+describe('Configurable products accessibility test suite', () => {
+    it('Check configurable product', () => {
+        cy.visit(product.configurableProductUrl)
+        cy.wait(1000)
+
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/products/product-simple.spec.js
+++ b/cypress/integration/luma-accessibility/products/product-simple.spec.js
@@ -1,0 +1,12 @@
+import product from "../../../fixtures/luma/product"
+import {checkAccessibility} from "../../../support/utils"
+
+describe('Simple Product accessibility test suite', () => {
+    it('Check simple product', () => {
+        cy.visit(product.simpleProductUrl)
+        cy.wait(2000)
+
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/search/product-search-suggestions.spec.js
+++ b/cypress/integration/luma-accessibility/search/product-search-suggestions.spec.js
@@ -3,7 +3,7 @@ import {checkAccessibility} from "../../../support/utils"
 import selectorsLuma from "../../../fixtures/luma/selectors/search.json";
 
 describe('Product search suggestions accessibility test', () => {
-    it('Check suggestions', () => {
+    it('Check search suggestions', () => {
         cy.visit('/')
         cy.get(selectorsLuma.headerSearchIcon).click()
         cy.get(selectorsLuma.headerSearchField)

--- a/cypress/integration/luma-accessibility/search/product-search-suggestions.spec.js
+++ b/cypress/integration/luma-accessibility/search/product-search-suggestions.spec.js
@@ -1,0 +1,17 @@
+import searchLuma from "../../../fixtures/luma/search"
+import {checkAccessibility} from "../../../support/utils"
+import selectorsLuma from "../../../fixtures/luma/selectors/search.json";
+
+describe('Product search suggestions accessibility test', () => {
+    it('Check suggestions', () => {
+        cy.visit('/')
+        cy.get(selectorsLuma.headerSearchIcon).click()
+        cy.get(selectorsLuma.headerSearchField)
+            .should('be.visible')
+            .type(`${searchLuma.getHint}`)
+
+        cy.wait(3000)
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/search/product-search-with-no-results.spec.js
+++ b/cypress/integration/luma-accessibility/search/product-search-with-no-results.spec.js
@@ -1,0 +1,12 @@
+import { Search } from "../../../page-objects/luma/search"
+import searchLuma from "../../../fixtures/luma/search"
+import {checkAccessibility} from "../../../support/utils"
+
+describe('Product search with no results accessibility test', () => {
+    it('Check search results', () => {
+        cy.visit('/')
+        Search.search(searchLuma.noResults)
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/search/product-search-with-no-results.spec.js
+++ b/cypress/integration/luma-accessibility/search/product-search-with-no-results.spec.js
@@ -3,7 +3,7 @@ import searchLuma from "../../../fixtures/luma/search"
 import {checkAccessibility} from "../../../support/utils"
 
 describe('Product search with no results accessibility test', () => {
-    it('Check search results', () => {
+    it('Check search results with no results', () => {
         cy.visit('/')
         Search.search(searchLuma.noResults)
         cy.injectAxe()

--- a/cypress/integration/luma-accessibility/search/product-search-with-results.spec.js
+++ b/cypress/integration/luma-accessibility/search/product-search-with-results.spec.js
@@ -1,0 +1,12 @@
+import { Search } from "../../../page-objects/luma/search"
+import searchLuma from "../../../fixtures/luma/search"
+import {checkAccessibility} from "../../../support/utils"
+
+describe('Product search with results accessibility test', () => {
+    it('Check search results', () => {
+        cy.visit('/')
+        Search.search(searchLuma.productCategory)
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/user/account-add-address.spec.js
+++ b/cypress/integration/luma-accessibility/user/account-add-address.spec.js
@@ -1,0 +1,15 @@
+import account from '../../../fixtures/account'
+import {checkAccessibility} from "../../../support/utils"
+import {Magento2RestApi} from "../../../support/magento2-rest-api";
+import {Account} from "../../../page-objects/luma/account";
+
+describe('Account add address accessibility test', () => {
+    it('Check add address page', () => {
+        Magento2RestApi.createCustomerAccount(account.customer)
+        Account.login(account.customer.customer.email, account.customer.password)
+
+        cy.visit(account.routes.accountAddAddress)
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/user/account-address-book.spec.js
+++ b/cypress/integration/luma-accessibility/user/account-address-book.spec.js
@@ -1,0 +1,37 @@
+import account from '../../../fixtures/account'
+import {checkAccessibility} from "../../../support/utils"
+import {Magento2RestApi} from "../../../support/magento2-rest-api";
+import {Account} from "../../../page-objects/luma/account";
+
+describe('Account address book accessibility test', () => {
+    before(() => {
+        cy.wait(2500)
+        Magento2RestApi.createCustomerAccount(account.customer)
+        Account.login(account.customer.customer.email, account.customer.password)
+        Account.createAddress(account.customerInfo)
+    })
+
+    after(() => {
+        // Remove the added address
+        cy.wait(4000)
+        cy.visit(account.routes.accountAddresses)
+        cy.wait(4000)
+        cy.get('.additional-addresses a.delete').eq(0).click({force: true})
+        cy.wait(1000)
+        cy.get('.modal-content').contains('Are you sure you want to delete this address?')
+        cy.get('.action-primary').click()
+        cy.wait(2500)
+    })
+
+    it('Check address book page', () => {
+        cy.visit(account.routes.accountAddAddress)
+        Account.createAddress(account.customerInfo)
+        cy.wait(2000)
+
+        cy.visit(account.routes.accountAddresses)
+        cy.injectAxe()
+
+        // We need to set skip failures as true here so the after gets called
+        checkAccessibility(null, null, true)
+    })
+})

--- a/cypress/integration/luma-accessibility/user/account-create.spec.js
+++ b/cypress/integration/luma-accessibility/user/account-create.spec.js
@@ -1,0 +1,10 @@
+import account from '../../../fixtures/account'
+import {checkAccessibility} from "../../../support/utils"
+
+describe('Account test creation', () => {
+    it('Check create an account page', () => {
+        cy.visit(account.routes.accountCreate)
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/user/account-edit.spec.js
+++ b/cypress/integration/luma-accessibility/user/account-edit.spec.js
@@ -1,0 +1,15 @@
+import account from '../../../fixtures/account'
+import {checkAccessibility} from "../../../support/utils"
+import {Magento2RestApi} from "../../../support/magento2-rest-api";
+import {Account} from "../../../page-objects/luma/account";
+
+describe('Account edit accessibility test', () => {
+    it('Check account edit page', () => {
+        Magento2RestApi.createCustomerAccount(account.customer)
+        Account.login(account.customer.customer.email, account.customer.password)
+
+        cy.visit(account.routes.accountEdit)
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/user/account-forgotten-password.spec.js
+++ b/cypress/integration/luma-accessibility/user/account-forgotten-password.spec.js
@@ -1,0 +1,10 @@
+import account from '../../../fixtures/account'
+import {checkAccessibility} from "../../../support/utils"
+
+describe('Account forgotten password accessibility test', () => {
+    it('Check forgotten password page', () => {
+        cy.visit(account.routes.accountForgottenPassword);
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/user/account-index.spec.js
+++ b/cypress/integration/luma-accessibility/user/account-index.spec.js
@@ -1,0 +1,15 @@
+import account from '../../../fixtures/account'
+import {checkAccessibility} from "../../../support/utils"
+import {Magento2RestApi} from "../../../support/magento2-rest-api";
+import {Account} from "../../../page-objects/luma/account";
+
+describe('Account index accessibility test', () => {
+    it('Check account index page', () => {
+        Magento2RestApi.createCustomerAccount(account.customer)
+        Account.login(account.customer.customer.email, account.customer.password)
+
+        cy.visit(account.routes.accountIndex);
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/user/account-login.spec.js
+++ b/cypress/integration/luma-accessibility/user/account-login.spec.js
@@ -1,0 +1,10 @@
+import account from '../../../fixtures/account'
+import {checkAccessibility} from "../../../support/utils"
+
+describe('Account login accessibility test', () => {
+    it('Check login page', () => {
+        cy.visit(account.routes.accountIndex);
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/user/account-logout.spec.js
+++ b/cypress/integration/luma-accessibility/user/account-logout.spec.js
@@ -1,0 +1,17 @@
+import account from '../../../fixtures/account'
+import {checkAccessibility} from "../../../support/utils"
+import {Magento2RestApi} from "../../../support/magento2-rest-api";
+import {Account} from "../../../page-objects/luma/account";
+import selectorsLuma from "../../../fixtures/luma/selectors/account.json";
+
+describe('Account logout accessibility test', () => {
+    it('Check logout page', () => {
+        Magento2RestApi.createCustomerAccount(account.customer)
+        Account.login(account.customer.customer.email, account.customer.password)
+
+        cy.get(selectorsLuma.accountIcon).click({force: true})
+        cy.get(selectorsLuma.accountMenuItems).contains('Sign Out').click({force: true})
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/user/account-newsletter.spec.js
+++ b/cypress/integration/luma-accessibility/user/account-newsletter.spec.js
@@ -1,0 +1,15 @@
+import account from '../../../fixtures/account'
+import {checkAccessibility} from "../../../support/utils"
+import {Magento2RestApi} from "../../../support/magento2-rest-api";
+import {Account} from "../../../page-objects/luma/account";
+
+describe('Account newsletter accessibility test', () => {
+    it('Check newsletter page', () => {
+        Magento2RestApi.createCustomerAccount(account.customer)
+        Account.login(account.customer.customer.email, account.customer.password)
+
+        cy.visit(account.routes.manageNewsletter)
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/user/account-order-history.spec.js
+++ b/cypress/integration/luma-accessibility/user/account-order-history.spec.js
@@ -1,0 +1,16 @@
+import account from '../../../fixtures/account'
+import {checkAccessibility} from "../../../support/utils"
+import {Magento2RestApi} from "../../../support/magento2-rest-api";
+import {Account} from "../../../page-objects/luma/account";
+
+describe('Account order history accessibility test', () => {
+    it('Check order history page', () => {
+        Magento2RestApi.createCustomerAccount(account.customer)
+        Account.login(account.customer.customer.email, account.customer.password)
+
+        // This test is dependent on if the user has or does not have orders
+        cy.visit(account.routes.accountOrderHistory)
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/integration/luma-accessibility/user/account-wishlist.spec.js
+++ b/cypress/integration/luma-accessibility/user/account-wishlist.spec.js
@@ -1,0 +1,20 @@
+import account from '../../../fixtures/account'
+import {checkAccessibility} from "../../../support/utils"
+import {Magento2RestApi} from "../../../support/magento2-rest-api";
+import {Account} from "../../../page-objects/luma/account";
+import product from "../../../fixtures/luma/product.json";
+import selectorsLuma from "../../../fixtures/luma/selectors/account.json";
+
+describe('Account wishlist accessibility test', () => {
+    it('Check wishlist page', () => {
+        Magento2RestApi.createCustomerAccount(account.customer)
+        Account.login(account.customer.customer.email, account.customer.password)
+
+        cy.visit(product.simpleProductUrl)
+        cy.wait(2000)
+        cy.get(selectorsLuma.addToWishlistButton).eq(0).click({force: true})
+        cy.visit(account.routes.wishlist)
+        cy.injectAxe()
+        checkAccessibility()
+    })
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,4 +1,5 @@
 import './commands'
+import 'cypress-axe'
 
 Cypress.on('uncaught:exception', (err, runnable) => {
     // returning false here prevents Cypress from failing the test

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -52,6 +52,6 @@ export function printAccessibilityViolations(violations) {
     );
 
 }
-export function checkAccessibility(subject, options, violationsCallback, skipFailures = false) {
-    cy.checkA11y(subject, null, printAccessibilityViolations, skipFailures);
+export function checkAccessibility(subject, options, skipFailures = false) {
+    cy.checkA11y(subject, options, printAccessibilityViolations, skipFailures);
 }

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -38,3 +38,20 @@ export function shouldHaveErrorMessage(message) {
         .should('exist')
         .should('contain.text', message)
 }
+
+export function printAccessibilityViolations(violations) {
+    cy.task(
+        'axetable',
+        violations.map(({ id, impact, description, nodes }) => ({
+            impact,
+            description: `${description} (${id})`,
+            nodes: nodes.length,
+            html: nodes.map(u => u.html).join(' \n '),
+            id: id
+        })),
+    );
+
+}
+export function checkAccessibility(subject, options, violationsCallback, skipFailures = false) {
+    cy.checkA11y(subject, null, printAccessibilityViolations, skipFailures);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,9 @@
   "packages": {
     "": {
       "devDependencies": {
+        "axe-core": "^4.8.2",
         "cypress": "^12.2.0",
+        "cypress-axe": "^1.5.0",
         "cypress-localstorage-commands": "^2.2.2",
         "cypress-tags": "^1.1.2",
         "typescript": "^4.8.3"
@@ -2243,6 +2245,15 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "node_modules/axe-core": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
+      "integrity": "sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/babel-plugin-add-module-exports": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz",
@@ -3165,6 +3176,19 @@
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cypress-axe": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.5.0.tgz",
+      "integrity": "sha512-Hy/owCjfj+25KMsecvDgo4fC/781ccL+e8p+UUYoadGVM2ogZF9XIKbiM6KI8Y3cEaSreymdD6ZzccbI2bY0lQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "axe-core": "^3 || ^4",
+        "cypress": "^10 || ^11 || ^12 || ^13"
       }
     },
     "node_modules/cypress-localstorage-commands": {
@@ -8080,6 +8104,12 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "axe-core": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
+      "integrity": "sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==",
+      "dev": true
+    },
     "babel-plugin-add-module-exports": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz",
@@ -8837,6 +8867,13 @@
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       }
+    },
+    "cypress-axe": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.5.0.tgz",
+      "integrity": "sha512-Hy/owCjfj+25KMsecvDgo4fC/781ccL+e8p+UUYoadGVM2ogZF9XIKbiM6KI8Y3cEaSreymdD6ZzccbI2bY0lQ==",
+      "dev": true,
+      "requires": {}
     },
     "cypress-localstorage-commands": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "devDependencies": {
+    "axe-core": "^4.8.2",
     "cypress": "^12.2.0",
+    "cypress-axe": "^1.5.0",
     "cypress-localstorage-commands": "^2.2.2",
     "cypress-tags": "^1.1.2",
     "typescript": "^4.8.3"


### PR DESCRIPTION
### Overview

A MR that's aim is to provide the option for accessibility tests using cypress-axe. #110 

### Pipeline

Currently, these tests are optional and as far as we can see do not run in the pipeline. Is this something that should be considered for the project or is leaving them optional fine for now?

### Order History Test Improvement

In our project we have 2 users setup that are imported in pipeline. 1 user has orders and 1 user does not have orders thus allowing us to test the order history page with and without orders easily without having to create an order via the tests itself and having a consistent test data state. This would be one suggesting for improvement we see here and also with the account tests in general to consider how items like orders are created for test cases. At the moment we have left this test exactly the same as the main account order history test.

### Address cleanup improvements

Again in our project we have our database cleaned for each test run, so we know that state at the beginning of each test. Here with the address test we are not 100% sure what the user's address state is in the spec. In the end I think we should test the address book with no addresses, with only default addresses and with extra addresses but for these tests we have stuck to the tests like they are in the normal test specs. At the moment we have left this test exactly the same as the main account order history test.

### Splitting account tests

As the cypress-axe assertion will by default be treated as an error when you add multiple tests into one spec the test spec will exit on first fail. It is possible to ignore this with a flag, for example see the checkout step tests, but the tests will then be marked as successful. We feel if the accessibility tests fail then they should really fail rather than fail silently. For this reason we have split all tests out into individual test specs so you get a better overview of the real errors.

### Tests allow failure

There are two cases when we have set the "allow failure" flag as true. Firstly in the checkout tests when we validate step 1 of the checkout and then process to step 2. Since there are errors in step 1 cypress by default would stop at these and not continue to step 2. The second time is during any account test with an after section. If there is a failure in the test itself then the after section, for example address cleanup, would not happen. So in this case we need to mark the test as allow failure to run the test clean up step.

### Hyvä tests

In our internal project we only have the single theme based on luma and as such to keep things simple have only provided the accessibility tests for luma, though it should be easily possible to create a second accessibility spec for hyvä if and when desired.
